### PR TITLE
CREATE機能の実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.1'
 	compileOnly 'org.projectlombok:lombok:1.18.24'
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.1'
-	implementation 'org.projectlombok:lombok:1.18.24'
-	implementation 'org.projectlombok:lombok:1.18.24'
+	compileOnly 'org.projectlombok:lombok:1.18.24'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS team;
+DROP TABLE IF EXISTS teams;
 
 CREATE TABLE teams (
   id int unsigned AUTO_INCREMENT,

--- a/src/main/java/com/raisetech/cruddemo/CreateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/CreateForm.java
@@ -1,0 +1,14 @@
+package com.raisetech.cruddemo;
+
+import lombok.Getter;
+
+@Getter
+public class CreateForm {
+    private int id;
+
+    private String team;
+
+    private String league;
+
+    private int foundingYear;
+}

--- a/src/main/java/com/raisetech/cruddemo/CreateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/CreateForm.java
@@ -1,14 +1,20 @@
 package com.raisetech.cruddemo;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class CreateForm {
+
     private int id;
 
+    @NotBlank
     private String name;
 
+    @NotBlank
     private String league;
 
+    @NotNull
     private int founding_year;
 }

--- a/src/main/java/com/raisetech/cruddemo/CreateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/CreateForm.java
@@ -17,5 +17,5 @@ public class CreateForm {
 
     @NotNull
     private int foundingYear;
-
 }
+

--- a/src/main/java/com/raisetech/cruddemo/CreateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/CreateForm.java
@@ -16,5 +16,6 @@ public class CreateForm {
     private String league;
 
     @NotNull
-    private int founding_year;
+    private int foundingYear;
+
 }

--- a/src/main/java/com/raisetech/cruddemo/CreateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/CreateForm.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 public class CreateForm {
     private int id;
 
-    private String team;
+    private String name;
 
     private String league;
 
-    private int foundingYear;
+    private int founding_year;
 }

--- a/src/main/java/com/raisetech/cruddemo/Team.java
+++ b/src/main/java/com/raisetech/cruddemo/Team.java
@@ -2,8 +2,10 @@ package com.raisetech.cruddemo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 public class Team {
     private int id;

--- a/src/main/java/com/raisetech/cruddemo/Team.java
+++ b/src/main/java/com/raisetech/cruddemo/Team.java
@@ -12,6 +12,6 @@ public class Team {
 
     private String league;
 
-    private int founding_year;
+    private int foundingYear;
 
 }

--- a/src/main/java/com/raisetech/cruddemo/Team.java
+++ b/src/main/java/com/raisetech/cruddemo/Team.java
@@ -8,10 +8,10 @@ import lombok.Getter;
 public class Team {
     private int id;
 
-    private String team;
+    private String name;
 
     private String league;
 
-    private int foundingYear;
+    private int founding_year;
 
 }

--- a/src/main/java/com/raisetech/cruddemo/Team.java
+++ b/src/main/java/com/raisetech/cruddemo/Team.java
@@ -1,5 +1,10 @@
 package com.raisetech.cruddemo;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class Team {
     private int id;
 
@@ -9,26 +14,4 @@ public class Team {
 
     private int foundingYear;
 
-    public Team(int id, String team, String league, int foundingYear) {
-        this.id = id;
-        this.team = team;
-        this.league = league;
-        this.foundingYear = foundingYear;
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public String getTeam() {
-        return team;
-    }
-
-    public String getLeague() {
-        return league;
-    }
-
-    public int getFoundingYear() {
-        return foundingYear;
-    }
 }

--- a/src/main/java/com/raisetech/cruddemo/Team.java
+++ b/src/main/java/com/raisetech/cruddemo/Team.java
@@ -2,10 +2,8 @@ package com.raisetech.cruddemo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class Team {
     private int id;

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,7 +1,6 @@
 package com.raisetech.cruddemo;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -11,7 +10,6 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 @RestController
 public class TeamController {
@@ -21,8 +19,6 @@ public class TeamController {
     public TeamController(TeamService teamService) {
         this.teamService = teamService;
     }
-
-    private final AtomicLong counter = new AtomicLong();
 
     @GetMapping
     public List<Team> getTames() {
@@ -36,6 +32,7 @@ public class TeamController {
 
     @PostMapping("/teams")
     public ResponseEntity<Map<String, Serializable>> createTeam(@Validated @RequestBody CreateForm form, UriComponentsBuilder uriBuilder) {
+        teamService.createTeam(form);
         int id = form.getId();
         URI url = uriBuilder.path("/name/" + id).
                 build().

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -48,4 +48,10 @@ public class TeamController {
         teamService.updateTeam(id, form);
         return ResponseEntity.ok(Map.of("message", "チームを更新しました。"));
     }
+
+    @DeleteMapping("/teams/{id}")
+    public ResponseEntity<Map<String, String>> deleteTeam(@PathVariable int id){
+        teamService.deleteTeam(id);
+        return ResponseEntity.ok(Map.of("message", "チームを削除しました。"));
+    }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,6 +1,8 @@
 package com.raisetech.cruddemo;
 
+import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -25,18 +27,25 @@ public class TeamController {
         return teamService.findAll();
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/teams/{id}")
     public Team getTeams(@Validated @PathVariable("id") int id) throws Exception {
         return teamService.findById(id);
     }
 
     @PostMapping("/teams")
     public ResponseEntity<Map<String, Serializable>> createTeam(@Validated @RequestBody CreateForm form, UriComponentsBuilder uriBuilder) {
+        System.out.println(form.getName());
         teamService.createTeam(form);
         int id = form.getId();
         URI url = uriBuilder.path("/name/" + id).
                 build().
                 toUri();
         return ResponseEntity.created(url).body(Map.of("id", id, "message", "チームが登録されました。"));
+    }
+
+    @PatchMapping("/teams/{id}")
+    public ResponseEntity<Map<String, String>> updateTeam(@PathVariable int id, @RequestBody UpdateForm form) {
+        teamService.updateTeam(id, form);
+        return ResponseEntity.ok(Map.of("message", "チームを更新しました。"));
     }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,17 +1,20 @@
 package com.raisetech.cruddemo;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 @RestController
 @RequestMapping("/teams")
 public class TeamController {
     private final TeamService teamService;
+    private final AtomicLong counter = new AtomicLong();
 
     @Autowired
     public TeamController(TeamService teamService) {
@@ -25,5 +28,15 @@ public class TeamController {
     @GetMapping("/{id}")
     public Team getTeams(@PathVariable("id") int id) throws Exception {
         return teamService.findById(id);
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<Map<Integer, String>> create(@RequestBody CreateForm form){
+        int id = (int) counter.incrementAndGet();
+        URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
+                .path("/teams/" + id)
+                .build()
+                .toUri();
+        return ResponseEntity.created(url).body(Map.of(id, "チームが登録されました。"));
     }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -2,9 +2,9 @@ package com.raisetech.cruddemo;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -26,12 +26,12 @@ public class TeamController {
         return teamService.findAll();
     }
     @GetMapping("/{id}")
-    public Team getTeams(@PathVariable("id") int id) throws Exception {
+    public Team getTeams(@Validated @PathVariable("id") int id) throws Exception {
         return teamService.findById(id);
     }
 
     @PostMapping("/create")
-    public ResponseEntity<Map<Integer, String>> createTeam(@RequestBody CreateForm form){
+    public ResponseEntity<Map<Integer, String>> createTeam(@Validated @RequestBody CreateForm form){
         int id = (int) counter.incrementAndGet();
         URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
                 .path("/name/" + id)

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,8 +1,6 @@
 package com.raisetech.cruddemo;
 
-import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,6 +1,5 @@
 package com.raisetech.cruddemo;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +12,6 @@ import java.util.Map;
 
 @RestController
 public class TeamController {
-    @Autowired
     private final TeamService teamService;
 
     public TeamController(TeamService teamService) {

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -1,42 +1,45 @@
 package com.raisetech.cruddemo;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 @RestController
-@RequestMapping("/teams")
 public class TeamController {
-    private final TeamService teamService;
-    private final AtomicLong counter = new AtomicLong();
-
     @Autowired
+    private final TeamService teamService;
+
     public TeamController(TeamService teamService) {
         this.teamService = teamService;
     }
+
+    private final AtomicLong counter = new AtomicLong();
 
     @GetMapping
     public List<Team> getTames() {
         return teamService.findAll();
     }
+
     @GetMapping("/{id}")
     public Team getTeams(@Validated @PathVariable("id") int id) throws Exception {
         return teamService.findById(id);
     }
 
-    @PostMapping("/create")
-    public ResponseEntity<Map<Integer, String>> createTeam(@Validated @RequestBody CreateForm form){
-        int id = (int) counter.incrementAndGet();
-        URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
-                .path("/name/" + id)
-                .build()
-                .toUri();
-        return ResponseEntity.created(url).body(Map.of(id, "チームが登録されました。"));
+    @PostMapping("/teams")
+    public ResponseEntity<Map<String, Serializable>> createTeam(@Validated @RequestBody CreateForm form, UriComponentsBuilder uriBuilder) {
+        int id = form.getId();
+        URI url = uriBuilder.path("/name/" + id).
+                build().
+                toUri();
+        return ResponseEntity.created(url).body(Map.of("id", id, "message", "チームが登録されました。"));
     }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamController.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamController.java
@@ -31,10 +31,10 @@ public class TeamController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<Map<Integer, String>> create(@RequestBody CreateForm form){
+    public ResponseEntity<Map<Integer, String>> createTeam(@RequestBody CreateForm form){
         int id = (int) counter.incrementAndGet();
         URI url = UriComponentsBuilder.fromUriString("http://localhost:8080")
-                .path("/teams/" + id)
+                .path("/name/" + id)
                 .build()
                 .toUri();
         return ResponseEntity.created(url).body(Map.of(id, "チームが登録されました。"));

--- a/src/main/java/com/raisetech/cruddemo/TeamMapper.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamMapper.java
@@ -2,6 +2,7 @@ package com.raisetech.cruddemo;
 
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 import javax.management.ValueExp;
@@ -16,6 +17,7 @@ public interface TeamMapper {
     @Select("SELECT * FROM teams WHERE id = #{id}")
     Optional<Team> findById(int id);
 
-    @Insert("INSERT INTO teams (id, name, league, founding_year) VALUES (#{id}, #{name}, #{league}, #{founding_year})")
+    @Insert("INSERT INTO teams (id, name, league, founding_year) VALUES (#{id}, #{name}, #{league}, #{foundingYear})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
     void createTeam(CreateForm form);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamMapper.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamMapper.java
@@ -20,4 +20,7 @@ public interface TeamMapper {
 
     @Update("UPDATE teams SET name = #{name}, league = #{league}, founding_year = #{foundingYear} WHERE id = #{id}")
     void updateTeam(UpdateForm form);
+
+    @Delete("DELETE FROM teams WHERE id = #{id}")
+    void deleteTeam(int id);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamMapper.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamMapper.java
@@ -1,9 +1,6 @@
 package com.raisetech.cruddemo;
 
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 import javax.management.ValueExp;
 import java.util.List;
@@ -20,4 +17,7 @@ public interface TeamMapper {
     @Insert("INSERT INTO teams (id, name, league, founding_year) VALUES (#{id}, #{name}, #{league}, #{foundingYear})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void createTeam(CreateForm form);
+
+    @Update("UPDATE teams SET name = #{name}, league = #{league}, founding_year = #{foundingYear} WHERE id = #{id}")
+    void updateTeam(UpdateForm form);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamMapper.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamMapper.java
@@ -1,8 +1,10 @@
 package com.raisetech.cruddemo;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
+import javax.management.ValueExp;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +15,7 @@ public interface TeamMapper {
 
     @Select("SELECT * FROM teams WHERE id = #{id}")
     Optional<Team> findById(int id);
+
+    @Insert("INSERT INTO teams (id, name, league, founding_year) VALUES (#{id}, #{name}, #{league}, #{founding_year})")
+    void createTeam(CreateForm form);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamService.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamService.java
@@ -7,5 +7,5 @@ public interface TeamService {
 
     Team findById(int id) throws Exception;
 
-    void create(String team);
+    void createTeam(CreateForm form);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamService.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamService.java
@@ -6,4 +6,6 @@ public interface TeamService {
     List<Team> findAll();
 
     Team findById(int id) throws Exception;
+
+    void create(String team);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamService.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamService.java
@@ -10,4 +10,6 @@ public interface TeamService {
     void createTeam(CreateForm form);
 
     void updateTeam(int id, UpdateForm form);
+
+    void deleteTeam(int id);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamService.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamService.java
@@ -8,4 +8,6 @@ public interface TeamService {
     Team findById(int id) throws Exception;
 
     void createTeam(CreateForm form);
+
+    void updateTeam(int id, UpdateForm form);
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
@@ -24,7 +24,7 @@ public class TeamServiceImpl implements TeamService{
     }
 
     @Override
-    public void create(String team) {
-
+    public void createTeam(CreateForm form){
+        teamMapper.createTeam(form);
     }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
@@ -22,4 +22,9 @@ public class TeamServiceImpl implements TeamService{
     public Team findById(int id) {
         return this.teamMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
     }
+
+    @Override
+    public void create(String team) {
+
+    }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
@@ -28,4 +28,10 @@ public class TeamServiceImpl implements TeamService {
     public void createTeam(CreateForm form) {
         teamMapper.createTeam(form);
     }
+
+    @Override
+    public void updateTeam(int id, UpdateForm form){
+        teamMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+        teamMapper.updateTeam(form);
+    }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class TeamServiceImpl implements TeamService{
+public class TeamServiceImpl implements TeamService {
     private final TeamMapper teamMapper;
 
     @Autowired
@@ -18,13 +18,14 @@ public class TeamServiceImpl implements TeamService{
     public List<Team> findAll() {
         return teamMapper.findAll();
     }
+
     @Override
     public Team findById(int id) {
         return this.teamMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
     }
 
     @Override
-    public void createTeam(CreateForm form){
+    public void createTeam(CreateForm form) {
         teamMapper.createTeam(form);
     }
 }

--- a/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
+++ b/src/main/java/com/raisetech/cruddemo/TeamServiceImpl.java
@@ -34,4 +34,10 @@ public class TeamServiceImpl implements TeamService {
         teamMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
         teamMapper.updateTeam(form);
     }
+
+    @Override
+    public void deleteTeam(int id){
+        teamMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+        teamMapper.deleteTeam(id);
+    }
 }

--- a/src/main/java/com/raisetech/cruddemo/UpdateForm.java
+++ b/src/main/java/com/raisetech/cruddemo/UpdateForm.java
@@ -1,0 +1,23 @@
+package com.raisetech.cruddemo;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UpdateForm {
+    private int id;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String league;
+
+    @NotNull
+    private int foundingYear;
+}


### PR DESCRIPTION
# 概要

CREATE機能を実装するブランチですが、こちらでUPDATE, DELETE機能まで実装しました。
サッカーチームのid、名前、所属リーグ、創立年を変更するUPDATE機能、削除するDELETE機能になります。
それぞれidが見つからない場合はエラーメッセージをレスポンスとして返すようにしています。

# 動作確認結果

元のテーブル

![スクリーンショット 2023-01-09 18 10 12](https://user-images.githubusercontent.com/118739580/211275439-95f66711-d607-48e2-9a51-1d9e67defd93.jpg)

UPDATE（id3のチーム名を変更）

![スクリーンショット 2023-01-09 18 13 38](https://user-images.githubusercontent.com/118739580/211275856-86597ab0-d515-44b5-853a-274badd4a008.jpg)

DELETE（id26のチームを削除）

![スクリーンショット 2023-01-09 18 13 15](https://user-images.githubusercontent.com/118739580/211276077-e384da1c-01e8-45a6-8793-ab7d7111d544.jpg)

変更結果

![スクリーンショット 2023-01-09 18 10 58](https://user-images.githubusercontent.com/118739580/211276248-e7e408ae-803c-4e02-bbac-d582cc5ec2fc.jpg)
